### PR TITLE
5.1. 저장한 관광지/경로 목록 페이지

### DIFF
--- a/gamgyul-front/public/images/Icon/delete.svg
+++ b/gamgyul-front/public/images/Icon/delete.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1025_2432" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
+<rect width="24" height="24" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_1025_2432)">
+<path d="M7 21C6.45 21 5.97917 20.8042 5.5875 20.4125C5.19583 20.0208 5 19.55 5 19V6H4V4H9V3H15V4H20V6H19V19C19 19.55 18.8042 20.0208 18.4125 20.4125C18.0208 20.8042 17.55 21 17 21H7ZM17 6H7V19H17V6ZM9 17H11V8H9V17ZM13 17H15V8H13V17Z" fill="#2C2C2E"/>
+</g>
+</svg>

--- a/gamgyul-front/src/App.jsx
+++ b/gamgyul-front/src/App.jsx
@@ -11,6 +11,7 @@ import LocationFormPage from "./pages/LocationFormPage";
 import { GlobalStyles } from "./style/global";
 import { LanguageProvider } from "./contexts/LanguageContext"; // LanguageProvider 추가
 import AttractionListPage from "./pages/AttractionListPage";
+import MyTripPage from "./pages/MyTripPage";
 function App() {
   return (
     <LanguageProvider>
@@ -24,6 +25,7 @@ function App() {
           <Route path="/map" element={<MapPage />} />
           <Route path="/complete" element={<CompletePage />} />
           <Route path="/attractions/:id" element={<AttractionListPage />} />
+          <Route path="/trip" element={<MyTripPage />} />
 
           {/* 추가 페이지 (임시) */}
           <Route path="/theme" element={<ThemeFormPage />} />

--- a/gamgyul-front/src/components/common/AttractionItem/index.jsx
+++ b/gamgyul-front/src/components/common/AttractionItem/index.jsx
@@ -29,7 +29,7 @@ const AttractionItem = ({ onDelete, isChecked, onCheckChange, type }) => {
         <AtrctItemInfo>
           {type === "CHECK" && (
             <StyledCheckBtn>
-              <img src={`/images/Icon/check_${bookmark}.svg`} alt="북마크버튼" onClick={() => handleCheckClick()} />
+              <img src={`/images/Icon/check_${bookmark}.svg`} alt="체크버튼" onClick={() => handleCheckClick()} />
             </StyledCheckBtn>
           )}
           <figure>

--- a/gamgyul-front/src/components/common/AttractionItem/index.jsx
+++ b/gamgyul-front/src/components/common/AttractionItem/index.jsx
@@ -4,12 +4,9 @@ import { useEffect, useState } from "react";
 import { applyFontStyles } from "../../../utils/fontStyles";
 
 /** 관광지 아이템 컴포넌트 (분리 필요) */
-const AttractionItem = ({ isChecked, onCheckChange }) => {
+const AttractionItem = ({ isChecked, onCheckChange, type }) => {
   const [bookmark, setBookmark] = useState("off");
   const [isModal, setIsModal] = useState(false);
-  // const type = "DELETE";
-  // const type = "CHECK";
-  const type = "BASIC";
 
   useEffect(() => {}, []);
 

--- a/gamgyul-front/src/components/common/AttractionItem/index.jsx
+++ b/gamgyul-front/src/components/common/AttractionItem/index.jsx
@@ -4,9 +4,8 @@ import { useEffect, useState } from "react";
 import { applyFontStyles } from "../../../utils/fontStyles";
 
 /** 관광지 아이템 컴포넌트 (분리 필요) */
-const AttractionItem = ({ isChecked, onCheckChange, type }) => {
+const AttractionItem = ({ onDelete, isChecked, onCheckChange, type }) => {
   const [bookmark, setBookmark] = useState("off");
-  const [isModal, setIsModal] = useState(false);
 
   useEffect(() => {}, []);
 
@@ -24,40 +23,37 @@ const AttractionItem = ({ isChecked, onCheckChange, type }) => {
     console.log("임시 체크박스 클릭 핸들러입니다.");
   };
 
-  /** 삭제 버튼 클릭 => 이후 추가 */
-  const handleDeleteClick = () => {
-    console.log("삭제 버튼을 클릭했습니다.");
-  };
-
   return (
     <AtrctItemContainer>
-      <AtrctItemInfo>
-        {type === "CHECK" && (
-          <StyledCheckBtn>
-            <img src={`/images/Icon/check_${bookmark}.svg`} alt="북마크버튼" onClick={() => handleCheckClick()} />
-          </StyledCheckBtn>
+      <AtrctItemContents>
+        <AtrctItemInfo>
+          {type === "CHECK" && (
+            <StyledCheckBtn>
+              <img src={`/images/Icon/check_${bookmark}.svg`} alt="북마크버튼" onClick={() => handleCheckClick()} />
+            </StyledCheckBtn>
+          )}
+          <figure>
+            <img src="" alt="관광지 이미지" />
+            <figcaption>
+              <h3>리스트이름</h3>
+              <p>리스트내용</p>
+            </figcaption>
+          </figure>
+        </AtrctItemInfo>
+        {type === "DELETE" ? (
+          <StyledIconBtn>
+            <img src={`/images/Icon/delete.svg`} alt="삭제버튼" onClick={onDelete} />
+          </StyledIconBtn>
+        ) : (
+          <StyledIconBtn>
+            <img
+              src={`/images/Icon/bookmark_${bookmark}.svg`}
+              alt="북마크버튼"
+              onClick={() => handleBookmarkClick(bookmark)}
+            />
+          </StyledIconBtn>
         )}
-        <figure>
-          <img src="" alt="관광지 이미지" />
-          <figcaption>
-            <h3>리스트이름</h3>
-            <p>리스트내용</p>
-          </figcaption>
-        </figure>
-      </AtrctItemInfo>
-      {type === "DELETE" ? (
-        <StyledIconBtn>
-          <img src={`/images/Icon/delete.svg`} alt="삭제버튼" onClick={() => handleDeleteClick()} />
-        </StyledIconBtn>
-      ) : (
-        <StyledIconBtn>
-          <img
-            src={`/images/Icon/bookmark_${bookmark}.svg`}
-            alt="북마크버튼"
-            onClick={() => handleBookmarkClick(bookmark)}
-          />
-        </StyledIconBtn>
-      )}
+      </AtrctItemContents>
     </AtrctItemContainer>
   );
 };
@@ -88,13 +84,22 @@ const AtrctItemInfo = styled.section`
   }
 `;
 
-/** 관광지 아이템 컴포넌트 스타일링 */
-const AtrctItemContainer = styled.li`
+const AtrctItemContents = styled.li`
+  width: 100%;
   height: 90px;
+  border-bottom: 1px solid ${theme.color.sub2};
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid ${theme.color.sub2};
+`;
+
+/** 관광지 아이템 컴포넌트 스타일링 */
+const AtrctItemContainer = styled.div`
+  padding: 0 20px;
+
+  &:hover {
+    background: #1eb17b0d;
+  }
 `;
 
 const StyledIconBtn = styled.button`
@@ -102,6 +107,7 @@ const StyledIconBtn = styled.button`
   height: 24px;
   border: none;
   background-color: inherit;
+  cursor: pointer;
 `;
 
 const StyledCheckBtn = styled.button`
@@ -111,8 +117,9 @@ const StyledCheckBtn = styled.button`
   background-color: inherit;
   margin-right: 16px;
   & > img {
+    cursor: pointer;
     width: 100%;
-    hegiht: 100%;
+    height: 100%;
   }
 `;
 

--- a/gamgyul-front/src/components/common/BackNaviBtn/index.jsx
+++ b/gamgyul-front/src/components/common/BackNaviBtn/index.jsx
@@ -25,6 +25,7 @@ const StyledBackBtn = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor: pointer;
 
   width: 50px;
   height: 50px;

--- a/gamgyul-front/src/components/common/Button/TabButton.style.jsx
+++ b/gamgyul-front/src/components/common/Button/TabButton.style.jsx
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+import { theme } from "../../../style/theme";
+import { applyFontStyles } from "../../../utils/fontStyles";
+
+export const TabButton = styled.button`
+  ${({ fontSize }) => applyFontStyles(fontSize)}
+  background-color: inherit;
+  width: ${({ btnCnt }) => (btnCnt ? `${100 / btnCnt}%` : "auto")};
+  height: 48px;
+  border: none;
+  border-bottom: 3px solid ${({ isActive }) => (isActive ? theme.color.primary : theme.color.gray3)};
+  color: ${({ isActive }) => !isActive && theme.color.gray2};
+`;

--- a/gamgyul-front/src/components/common/Button/index.jsx
+++ b/gamgyul-front/src/components/common/Button/index.jsx
@@ -2,22 +2,31 @@ import styled from "styled-components";
 import { theme } from "../../../style/theme";
 import { applyFontStyles } from "../../../utils/fontStyles";
 
-const Button = ({ type, size, onClick, children, color, className, disabled, ...props }) => {
+const Button = ({ type, size, onClick, children, color, className, disabled, isShadow, ...props }) => {
   return (
-    <StyledButton type={type} size={size} onClick={onClick} color={color} className={className} disabled={disabled}>
+    <StyledButton
+      type={type}
+      size={size}
+      onClick={onClick}
+      color={color}
+      className={className}
+      disabled={disabled}
+      isShadow={isShadow}
+    >
       {children}
     </StyledButton>
   );
 };
 
 const StyledButton = styled.button`
-  ${applyFontStyles(theme.font.body1)}
+  ${applyFontStyles(theme.font.body2)}
   width: 100%;
-  height: ${({ type }) => (type === "small" ? "40px" : "64px")};
-  border-radius: 10px;
+  height: ${({ type }) => (type === "small" ? "42px" : "55px")};
+  border-radius: 20px;
   border: 0;
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
   background-color: ${({ disabled }) => (disabled ? theme.color.grayscale_BF : theme.color.primary)};
   color: ${theme.color.white};
+  box-shadow: ${({ isShadow }) => (isShadow ? "0px 2px 2px 0px #00000033" : "none")};
 `;
 export default Button;

--- a/gamgyul-front/src/components/common/Button/index.jsx
+++ b/gamgyul-front/src/components/common/Button/index.jsx
@@ -22,11 +22,12 @@ const StyledButton = styled.button`
   ${applyFontStyles(theme.font.body2)}
   width: 100%;
   height: ${({ type }) => (type === "small" ? "42px" : "55px")};
-  border-radius: 20px;
+  border-radius: ${({ type }) => (type === "small" ? "10px" : "20px")};
   border: 0;
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
-  background-color: ${({ disabled }) => (disabled ? theme.color.grayscale_BF : theme.color.primary)};
-  color: ${theme.color.white};
+  background-color: ${({ disabled, color }) =>
+    disabled ? theme.color.gray2 : color === "gray" ? theme.color.white : theme.color.primary};
+  color: ${({ color }) => (color === "gray" ? theme.color.gray2 : theme.color.white)};
   box-shadow: ${({ isShadow }) => (isShadow ? "0px 2px 2px 0px #00000033" : "none")};
 `;
 export default Button;

--- a/gamgyul-front/src/components/common/Modal/index.jsx
+++ b/gamgyul-front/src/components/common/Modal/index.jsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import styled from "styled-components";
+import { theme } from "../../../style/theme";
+
+const Modal = ({ onClose, onClick, type }) => {
+  const [routeValue, setRouteValue] = useState("");
+  // 경로 삭제일 때 : 확인 => 경로 삭제 api 요청 / 취소 => 모달 닫기
+  // 경로 저장일 때 : 확인 => 경로 저장 api 요청 / 취소 => 모달 닫기
+  return (
+    <ModalOverlayContainer>
+      <ModalContents>
+        {type === "DELETE" && <h2>경로를 삭제 하시겠어요?</h2>}
+        <h2>{type === "DELETE" ? "" : "경로 이름"}</h2>
+        {type === "SAVE" && (
+          <section>
+            <p>경로를 저장하려면 이름이 필요합니다.</p>
+            <input
+              type="text"
+              id="route-input"
+              value={routeValue}
+              placeholder="할망 여행"
+              onChange={(event) => setRouteValue(event.target.value)}
+            />
+          </section>
+        )}
+        <button onClick={onClose}>취소</button>
+        <button onClick={onClick}>확인</button>
+      </ModalContents>
+    </ModalOverlayContainer>
+  );
+};
+
+const ModalOverlayContainer = styled.div`
+`;
+
+const ModalContents = styled.div`
+`;
+
+export default Modal;

--- a/gamgyul-front/src/components/common/Modal/index.jsx
+++ b/gamgyul-front/src/components/common/Modal/index.jsx
@@ -1,39 +1,112 @@
 import { useState } from "react";
 import styled from "styled-components";
 import { theme } from "../../../style/theme";
+import { applyFontStyles } from "../../../utils/fontStyles";
+import Button from "../Button";
 
 const Modal = ({ onClose, onClick, type }) => {
   const [routeValue, setRouteValue] = useState("");
+  const isSaveButtonDisabled = type === "SAVE" && routeValue.trim() === "";
   // 경로 삭제일 때 : 확인 => 경로 삭제 api 요청 / 취소 => 모달 닫기
   // 경로 저장일 때 : 확인 => 경로 저장 api 요청 / 취소 => 모달 닫기
+
   return (
     <ModalOverlayContainer>
       <ModalContents>
-        {type === "DELETE" && <h2>경로를 삭제 하시겠어요?</h2>}
-        <h2>{type === "DELETE" ? "" : "경로 이름"}</h2>
+        {type === "DELETE" && <ModalDeleteH2>경로를 삭제 하시겠어요?</ModalDeleteH2>}
         {type === "SAVE" && (
-          <section>
+          <ModalRoutesSection>
+            <h2>경로 이름</h2>
             <p>경로를 저장하려면 이름이 필요합니다.</p>
-            <input
+            <StyledInputBox
               type="text"
               id="route-input"
               value={routeValue}
-              placeholder="할망 여행"
+              placeholder="이름을 입력해주세요."
               onChange={(event) => setRouteValue(event.target.value)}
             />
-          </section>
+          </ModalRoutesSection>
         )}
-        <button onClick={onClose}>취소</button>
-        <button onClick={onClick}>확인</button>
+        <div>
+          <StyledModalBtn type="small" onClick={onClose} color="gray">
+            취소
+          </StyledModalBtn>
+          <StyledModalBtn type="small" onClick={() => onClick(routeValue)} disabled={isSaveButtonDisabled}>
+            확인
+          </StyledModalBtn>
+        </div>
       </ModalContents>
     </ModalOverlayContainer>
   );
 };
 
+const ModalDeleteH2 = styled.h2`
+  width: 100%;
+  padding: 0 8px;
+  margin-top: 80px;
+  box-sizing: border-box;
+  text-align: center;
+`;
+
 const ModalOverlayContainer = styled.div`
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  max-width: ${theme.maxWidth};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+  background: #00000066;
 `;
 
 const ModalContents = styled.div`
+  width: 100%;
+  min-height: 252px;
+  border-radius: 20px;
+  padding: 14px 16px;
+  box-sizing: border-box;
+  box-shadow: 0px 2px 10px 0px #0000001a;
+  max-width: calc(${theme.maxWidth} - 88px);
+  background-color: ${theme.color.white};
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  h2 {
+    ${applyFontStyles(theme.font.subtitle)}
+  }
+
+  Button:last-child {
+    margin-right: 0;
+  }
+`;
+
+const StyledModalBtn = styled(Button)`
+  width: calc(50% - 4px);
+  margin-right: 8px;
+`;
+
+const ModalRoutesSection = styled.section`
+  margin: 10px 8px;
+  p {
+    ${applyFontStyles(theme.font.body3)}
+    margin: 4px 0 28px 0;
+  }
+`;
+
+const StyledInputBox = styled.input`
+  ${applyFontStyles(theme.font.body2)}
+  width: 100%;
+  height: 42px;
+  border: none;
+  border-bottom: 1px solid ${theme.color.primary};
+  box-sizing: border-box;
+  padding: 10px;
+
+  &::placeholder {
+    color: ${theme.color.gray2};
+  }
 `;
 
 export default Modal;

--- a/gamgyul-front/src/components/common/NavigationBar/index.jsx
+++ b/gamgyul-front/src/components/common/NavigationBar/index.jsx
@@ -40,7 +40,7 @@ const NaviContainer = styled.div`
   bottom: 0;
   left: 50%;
   transform: translateX(-50%);
-  width: 100%;
+  width: ${theme.maxWidth};
   display: flex;
   justify-content: space-around;
   background-color: #f6faed;

--- a/gamgyul-front/src/components/common/NavigationBar/index.jsx
+++ b/gamgyul-front/src/components/common/NavigationBar/index.jsx
@@ -1,11 +1,16 @@
-import { useState } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Link, useLocation, useParams } from "react-router-dom";
 import styled from "styled-components";
 import { theme } from "../../../style/theme";
 import { applyFontStyles } from "../../../utils/fontStyles";
 
 const NavigationBar = () => {
-  const [activeTab, setActiveTab] = useState("map");
+  const location = useLocation();
+  const [activeTab, setActiveTab] = useState(location.pathname);
+
+  useEffect(() => {
+    setActiveTab(location.pathname);
+  }, [location.pathname]);
 
   const handleTabClick = (tab) => {
     setActiveTab(tab);
@@ -13,23 +18,23 @@ const NavigationBar = () => {
 
   return (
     <NaviContainer>
-      <NavbarLink to="/complete" onClick={() => handleTabClick("map")}>
+      <NavbarLink to="/complete" onClick={() => handleTabClick("/map")}>
         <NaviBtn
-          src={activeTab === "map" ? "/src/assets/NavigationBar/mapOn.svg" : "/src/assets/NavigationBar/mapOff.svg"}
+          src={activeTab === "/map" ? "/src/assets/NavigationBar/mapOn.svg" : "/src/assets/NavigationBar/mapOff.svg"}
         />
-        <NaviText $active={activeTab === "map"}>Map</NaviText>
+        <NaviText $active={activeTab === "/map"}>Map</NaviText>
       </NavbarLink>
-      <NavbarLink to="/detail" onClick={() => handleTabClick("home")}>
+      <NavbarLink to="/home" onClick={() => handleTabClick("/home")}>
         <NaviBtn
-          src={activeTab === "home" ? "/src/assets/NavigationBar/homeOn.svg" : "/src/assets/NavigationBar/homeOff.svg"}
+          src={activeTab === "/home" ? "/src/assets/NavigationBar/homeOn.svg" : "/src/assets/NavigationBar/homeOff.svg"}
         />
-        <NaviText $active={activeTab === "home"}>Home</NaviText>
+        <NaviText $active={activeTab === "/home"}>Home</NaviText>
       </NavbarLink>
-      <NavbarLink to="/detail2" onClick={() => handleTabClick("trip")}>
+      <NavbarLink to="/trip" onClick={() => handleTabClick("/trip")}>
         <NaviBtn
-          src={activeTab === "trip" ? "/src/assets/NavigationBar/tripOn.svg" : "/src/assets/NavigationBar/tripOff.svg"}
+          src={activeTab === "/trip" ? "/src/assets/NavigationBar/tripOn.svg" : "/src/assets/NavigationBar/tripOff.svg"}
         />
-        <NaviText $active={activeTab === "trip"}>My Trip</NaviText>
+        <NaviText $active={activeTab === "/trip"}>My Trip</NaviText>
       </NavbarLink>
     </NaviContainer>
   );

--- a/gamgyul-front/src/components/common/TempModal/index.jsx
+++ b/gamgyul-front/src/components/common/TempModal/index.jsx
@@ -5,7 +5,7 @@ import { styled } from "styled-components";
 import { Link } from "react-router-dom";
 import { applyFontStyles } from "../../../utils/fontStyles";
 
-const Modal = ({ onClose }) => {
+const TempModal = ({ onClose }) => {
   return (
     <StyledOverlay>
       <StyledModal>
@@ -71,4 +71,4 @@ const StyledStampWrap = styled.div`
   }
 `;
 
-export default Modal;
+export default TempModal;

--- a/gamgyul-front/src/pages/AttractionListPage/index.jsx
+++ b/gamgyul-front/src/pages/AttractionListPage/index.jsx
@@ -23,19 +23,17 @@ const AttractionListPage = () => {
             <p>제주를 대표하는 과 관련된 장소를 여행해보세요.</p>
           </Container>
         </StyledAtrctHeader>
-        <Container>
-          <StyledListSection>
-            <ul>
-              {/* {data.map((element, index) => {
+        <StyledListSection>
+          <ul>
+            {/* {data.map((element, index) => {
               return <AttractionItem />;
             })} */}
 
-              <AttractionItem />
-              <AttractionItem />
-              <AttractionItem />
-            </ul>
-          </StyledListSection>
-        </Container>
+            <AttractionItem />
+            <AttractionItem />
+            <AttractionItem />
+          </ul>
+        </StyledListSection>
       </AttractionListContainer>
     </BasicLayout>
   );

--- a/gamgyul-front/src/pages/HomePage/index.jsx
+++ b/gamgyul-front/src/pages/HomePage/index.jsx
@@ -4,6 +4,7 @@ import { theme } from "../../style/theme";
 import { BasicLayout, Container } from "../../components/common/BasicLayout/layout.style";
 import { Link, useNavigate } from "react-router-dom";
 import { applyFontStyles } from "../../utils/fontStyles";
+import NavigationBar from "../../components/common/NavigationBar";
 
 const HomePage = () => {
   const navigate = useNavigate();
@@ -121,6 +122,7 @@ const HomePage = () => {
             </ul>
           </nav>
         </StyledRouteAtrct>
+        <NavigationBar />
       </BasicLayout>
     </>
   );

--- a/gamgyul-front/src/pages/MapDetailPage/index.jsx
+++ b/gamgyul-front/src/pages/MapDetailPage/index.jsx
@@ -3,10 +3,10 @@ import Button from "../../components/common/Button";
 import { FormLayout, StyledBottomWrapper } from "../ThemeFormPage";
 import { theme } from "../../style/theme";
 import { useEffect, useState } from "react";
-import Modal from "../../components/common/Modal";
 import axios from "axios";
 import { Link } from "react-router-dom";
 import { applyFontStyles } from "../../utils/fontStyles";
+import TempModal from "../../components/common/TempModal";
 
 const MapDetailPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -41,7 +41,7 @@ const MapDetailPage = () => {
 
   return (
     <>
-      {isModalOpen && <Modal onClose={handleCloseModal} />}
+      {isModalOpen && <TempModal onClose={handleCloseModal} />}
       <StyledFormLayout>
         <StyledPictureStamp>
           <StyledLocationPicture style={{ backgroundImage: `url(${mapDetailData?.placePictureUrl})` }} />

--- a/gamgyul-front/src/pages/MapDetailPage2/index.jsx
+++ b/gamgyul-front/src/pages/MapDetailPage2/index.jsx
@@ -3,10 +3,10 @@ import Button from "../../components/common/Button";
 import { FormLayout, StyledBottomWrapper } from "../ThemeFormPage";
 import { theme } from "../../style/theme";
 import { useEffect, useState } from "react";
-import Modal from "../../components/common/Modal";
 import axios from "axios";
 import { Link } from "react-router-dom";
 import { applyFontStyles } from "../../utils/fontStyles";
+import TempModal from "../../components/common/TempModal";
 
 const MapDetailPage2 = () => {
   const dataId = window.localStorage.getItem("placeId");
@@ -40,7 +40,7 @@ const MapDetailPage2 = () => {
 
   return (
     <>
-      {isModalOpen && <Modal onClose={handleCloseModal} />}
+      {isModalOpen && <TempModal onClose={handleCloseModal} />}
       <StyledFormLayout>
         <StyledPictureStamp>
           <StyledLocationPicture style={{ backgroundImage: `url(${mapDetailData?.placePictureUrl})` }} />

--- a/gamgyul-front/src/pages/MyTripPage/index.jsx
+++ b/gamgyul-front/src/pages/MyTripPage/index.jsx
@@ -50,18 +50,19 @@ const MyTripPage = () => {
           )}
           {activeTab === "routes" && (
             <>
-              <section>
+              <StyledRoutesSection>
                 <h3>저장한 경로</h3>
                 <AttractionItem />
                 <AttractionItem />
                 <AttractionItem />
-              </section>
-              <section>
+              </StyledRoutesSection>
+              <StyledRoutesSection>
                 <h3>내가 만든 경로</h3>
-                <AttractionItem />
-                <AttractionItem />
-                <AttractionItem />
-              </section>
+                <AttractionItem type="DELETE" />
+                <AttractionItem type="DELETE" />
+                <AttractionItem type="DELETE" />
+                <AttractionItem type="DELETE" />
+              </StyledRoutesSection>
             </>
           )}
         </Container>
@@ -75,6 +76,13 @@ const MyTripContainer = styled.div``;
 
 const StyledPlacesSection = styled.section`
   margin: 8px 0 80px 0;
+`;
+
+const StyledRoutesSection = styled.section`
+  margin: 20px 0 4px 0;
+  h3 {
+    ${applyFontStyles(theme.font.body1)}
+  }
 `;
 
 const StyledMyTripHeader = styled.header`

--- a/gamgyul-front/src/pages/MyTripPage/index.jsx
+++ b/gamgyul-front/src/pages/MyTripPage/index.jsx
@@ -13,8 +13,8 @@ const MyTripPage = () => {
   const [activeTab, setActiveTab] = useState("places");
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  /** 모달 임시 클릭 (달성 조건 추가 필요) */
-  const handleButtonClick = () => {
+  /** 삭제 아이콘 클릭 */
+  const handleDeleteClick = () => {
     setIsModalOpen(true);
   };
   /** 모달 닫기 */
@@ -22,9 +22,15 @@ const MyTripPage = () => {
     setIsModalOpen(false);
   };
 
+  /** 모달 확인 버튼 클릭 */
+  const handleModalCheck = (value) => {
+    // API 요청
+    console.log(value);
+  };
+
   return (
     <MyTripLayout>
-      {isModalOpen && <Modal type="DELETE" onClose={handleCloseModal} />}
+      {isModalOpen && <Modal type="DELETE" onClick={handleModalCheck} onClose={handleCloseModal} />}
       <MyTripContainer>
         <StyledMyTripHeader>
           <Container>
@@ -74,11 +80,11 @@ const MyTripPage = () => {
               <Container>
                 <h3>내가 만든 경로</h3>
               </Container>
-              <AttractionItem type="DELETE" onDelete={handleButtonClick} />
-              <AttractionItem type="DELETE" onDelete={handleButtonClick} />
-              <AttractionItem type="DELETE" onDelete={handleButtonClick} />
-              <AttractionItem type="DELETE" onDelete={handleButtonClick} />
-              <AttractionItem type="DELETE" onDelete={handleButtonClick} />
+              <AttractionItem type="DELETE" onDelete={handleDeleteClick} />
+              <AttractionItem type="DELETE" onDelete={handleDeleteClick} />
+              <AttractionItem type="DELETE" onDelete={handleDeleteClick} />
+              <AttractionItem type="DELETE" onDelete={handleDeleteClick} />
+              <AttractionItem type="DELETE" onDelete={handleDeleteClick} />
             </StyledRoutesSection>
           </>
         )}

--- a/gamgyul-front/src/pages/MyTripPage/index.jsx
+++ b/gamgyul-front/src/pages/MyTripPage/index.jsx
@@ -2,17 +2,38 @@ import { useState } from "react";
 import AttractionItem from "../../components/common/AttractionItem";
 import { BasicLayout, Container } from "../../components/common/BasicLayout/layout.style";
 import styled from "styled-components";
+import { applyFontStyles } from "../../utils/fontStyles";
+import { theme } from "../../style/theme";
+import { TabButton } from "../../components/common/Button/TabButton.style";
 
 const MyTripPage = () => {
   const [activeTab, setActiveTab] = useState("places");
   return (
     <BasicLayout>
       <MyTripContainer>
-        <h2>내 여행</h2>
-        <nav aria-label="내 여행 (장소 / 경로)">
-          <button onClick={() => setActiveTab("places")}>장소</button>
-          <button onClick={() => setActiveTab("routes")}>경로</button>
-        </nav>
+        <StyledMyTripHeader>
+          <Container>
+            <h2>내 여행</h2>
+          </Container>
+          <nav aria-label="내 여행 (장소 / 경로)">
+            <TabButton
+              onClick={() => setActiveTab("places")}
+              isActive={activeTab === "places"}
+              fontSize={theme.font.body1}
+              btnCnt={2}
+            >
+              장소
+            </TabButton>
+            <TabButton
+              onClick={() => setActiveTab("routes")}
+              isActive={activeTab === "routes"}
+              fontSize={theme.font.body1}
+              btnCnt={2}
+            >
+              경로
+            </TabButton>
+          </nav>
+        </StyledMyTripHeader>
 
         <section>
           <Container>
@@ -50,5 +71,13 @@ const MyTripPage = () => {
 };
 
 const MyTripContainer = styled.div``;
+
+const StyledMyTripHeader = styled.header`
+  padding-top: 54px;
+  h2 {
+    ${applyFontStyles(theme.font.header)}
+    margin: 24px 0 10px 0;
+  }
+`;
 
 export default MyTripPage;

--- a/gamgyul-front/src/pages/MyTripPage/index.jsx
+++ b/gamgyul-front/src/pages/MyTripPage/index.jsx
@@ -96,6 +96,7 @@ const StyledMyTripHeader = styled.header`
 
 const MyTripLayout = styled(BasicLayout)`
   background-color: ${theme.color.white};
+  position: relative;
 `;
 
 const MyTripButton = styled(Button)`
@@ -104,7 +105,7 @@ const MyTripButton = styled(Button)`
   left: 50%;
   transform: translateX(-50%);
   z-index: 1000;
-  width: calc(100% - 40px);
+  max-width: calc(${theme.maxWidth} - 40px);
 `;
 
 export default MyTripPage;

--- a/gamgyul-front/src/pages/MyTripPage/index.jsx
+++ b/gamgyul-front/src/pages/MyTripPage/index.jsx
@@ -7,11 +7,24 @@ import { theme } from "../../style/theme";
 import { TabButton } from "../../components/common/Button/TabButton.style";
 import Button from "../../components/common/Button";
 import NavigationBar from "../../components/common/NavigationBar";
+import Modal from "../../components/common/Modal";
 
 const MyTripPage = () => {
   const [activeTab, setActiveTab] = useState("places");
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  /** 모달 임시 클릭 (달성 조건 추가 필요) */
+  const handleButtonClick = () => {
+    setIsModalOpen(true);
+  };
+  /** 모달 닫기 */
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
   return (
     <MyTripLayout>
+      {isModalOpen && <Modal type="DELETE" onClose={handleCloseModal} />}
       <MyTripContainer>
         <StyledMyTripHeader>
           <Container>
@@ -37,35 +50,38 @@ const MyTripPage = () => {
           </nav>
         </StyledMyTripHeader>
 
-        <Container>
-          {activeTab === "places" && (
-            <StyledPlacesSection>
-              <AttractionItem type="CHECK" />
-              <AttractionItem type="CHECK" />
-              <AttractionItem type="CHECK" />
-              <AttractionItem type="CHECK" />
-              <AttractionItem type="CHECK" />
-              <MyTripButton isShadow={true}>내 경로 만들기</MyTripButton>
-            </StyledPlacesSection>
-          )}
-          {activeTab === "routes" && (
-            <>
-              <StyledRoutesSection>
+        {activeTab === "places" && (
+          <StyledPlacesSection>
+            <AttractionItem type="CHECK" />
+            <AttractionItem type="CHECK" />
+            <AttractionItem type="CHECK" />
+            <AttractionItem type="CHECK" />
+            <AttractionItem type="CHECK" />
+            <MyTripButton isShadow={true}>내 경로 만들기</MyTripButton>
+          </StyledPlacesSection>
+        )}
+        {activeTab === "routes" && (
+          <>
+            <StyledRoutesSection>
+              <Container>
                 <h3>저장한 경로</h3>
-                <AttractionItem />
-                <AttractionItem />
-                <AttractionItem />
-              </StyledRoutesSection>
-              <StyledRoutesSection>
+              </Container>
+              <AttractionItem />
+              <AttractionItem />
+              <AttractionItem />
+            </StyledRoutesSection>
+            <StyledRoutesSection>
+              <Container>
                 <h3>내가 만든 경로</h3>
-                <AttractionItem type="DELETE" />
-                <AttractionItem type="DELETE" />
-                <AttractionItem type="DELETE" />
-                <AttractionItem type="DELETE" />
-              </StyledRoutesSection>
-            </>
-          )}
-        </Container>
+              </Container>
+              <AttractionItem type="DELETE" onDelete={handleButtonClick} />
+              <AttractionItem type="DELETE" onDelete={handleButtonClick} />
+              <AttractionItem type="DELETE" onDelete={handleButtonClick} />
+              <AttractionItem type="DELETE" onDelete={handleButtonClick} />
+              <AttractionItem type="DELETE" onDelete={handleButtonClick} />
+            </StyledRoutesSection>
+          </>
+        )}
       </MyTripContainer>
       <NavigationBar />
     </MyTripLayout>

--- a/gamgyul-front/src/pages/MyTripPage/index.jsx
+++ b/gamgyul-front/src/pages/MyTripPage/index.jsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import AttractionItem from "../../components/common/AttractionItem";
+import { BasicLayout, Container } from "../../components/common/BasicLayout/layout.style";
+import styled from "styled-components";
+
+const MyTripPage = () => {
+  const [activeTab, setActiveTab] = useState("places");
+  return (
+    <BasicLayout>
+      <MyTripContainer>
+        <h2>내 여행</h2>
+        <nav aria-label="내 여행 (장소 / 경로)">
+          <button onClick={() => setActiveTab("places")}>장소</button>
+          <button onClick={() => setActiveTab("routes")}>경로</button>
+        </nav>
+
+        <section>
+          <Container>
+            {activeTab === "places" && (
+              <>
+                <AttractionItem />
+                <AttractionItem />
+                <AttractionItem />
+                <AttractionItem />
+                <AttractionItem />
+                <button>내 경로 만들기</button>
+              </>
+            )}
+            {activeTab === "routes" && (
+              <>
+                <section>
+                  <h3>저장한 경로</h3>
+                  <AttractionItem />
+                  <AttractionItem />
+                  <AttractionItem />
+                </section>
+                <section>
+                  <h3>내가 만든 경로</h3>
+                  <AttractionItem />
+                  <AttractionItem />
+                  <AttractionItem />
+                </section>
+              </>
+            )}
+          </Container>
+        </section>
+      </MyTripContainer>
+    </BasicLayout>
+  );
+};
+
+const MyTripContainer = styled.div``;
+
+export default MyTripPage;

--- a/gamgyul-front/src/pages/MyTripPage/index.jsx
+++ b/gamgyul-front/src/pages/MyTripPage/index.jsx
@@ -5,11 +5,13 @@ import styled from "styled-components";
 import { applyFontStyles } from "../../utils/fontStyles";
 import { theme } from "../../style/theme";
 import { TabButton } from "../../components/common/Button/TabButton.style";
+import Button from "../../components/common/Button";
+import NavigationBar from "../../components/common/NavigationBar";
 
 const MyTripPage = () => {
   const [activeTab, setActiveTab] = useState("places");
   return (
-    <BasicLayout>
+    <MyTripLayout>
       <MyTripContainer>
         <StyledMyTripHeader>
           <Container>
@@ -35,49 +37,66 @@ const MyTripPage = () => {
           </nav>
         </StyledMyTripHeader>
 
-        <section>
-          <Container>
-            {activeTab === "places" && (
-              <>
+        <Container>
+          {activeTab === "places" && (
+            <StyledPlacesSection>
+              <AttractionItem type="CHECK" />
+              <AttractionItem type="CHECK" />
+              <AttractionItem type="CHECK" />
+              <AttractionItem type="CHECK" />
+              <AttractionItem type="CHECK" />
+              <MyTripButton isShadow={true}>내 경로 만들기</MyTripButton>
+            </StyledPlacesSection>
+          )}
+          {activeTab === "routes" && (
+            <>
+              <section>
+                <h3>저장한 경로</h3>
                 <AttractionItem />
                 <AttractionItem />
                 <AttractionItem />
+              </section>
+              <section>
+                <h3>내가 만든 경로</h3>
                 <AttractionItem />
                 <AttractionItem />
-                <button>내 경로 만들기</button>
-              </>
-            )}
-            {activeTab === "routes" && (
-              <>
-                <section>
-                  <h3>저장한 경로</h3>
-                  <AttractionItem />
-                  <AttractionItem />
-                  <AttractionItem />
-                </section>
-                <section>
-                  <h3>내가 만든 경로</h3>
-                  <AttractionItem />
-                  <AttractionItem />
-                  <AttractionItem />
-                </section>
-              </>
-            )}
-          </Container>
-        </section>
+                <AttractionItem />
+              </section>
+            </>
+          )}
+        </Container>
       </MyTripContainer>
-    </BasicLayout>
+      <NavigationBar />
+    </MyTripLayout>
   );
 };
 
 const MyTripContainer = styled.div``;
 
+const StyledPlacesSection = styled.section`
+  margin: 8px 0 80px 0;
+`;
+
 const StyledMyTripHeader = styled.header`
   padding-top: 54px;
+  background-color: ${theme.color.background};
   h2 {
     ${applyFontStyles(theme.font.header)}
     margin: 24px 0 10px 0;
   }
+`;
+
+const MyTripLayout = styled(BasicLayout)`
+  background-color: ${theme.color.white};
+`;
+
+const MyTripButton = styled(Button)`
+  position: fixed;
+  bottom: 99px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  width: calc(100% - 40px);
 `;
 
 export default MyTripPage;

--- a/gamgyul-front/src/style/global.jsx
+++ b/gamgyul-front/src/style/global.jsx
@@ -24,7 +24,7 @@ export const GlobalStyles = createGlobalStyle`
     
     .layout {
       height: 100vh;
-      max-width: 375px;
+      max-width: ${theme.maxWidth};
       margin: 0 auto;
     }
 

--- a/gamgyul-front/src/style/theme.jsx
+++ b/gamgyul-front/src/style/theme.jsx
@@ -1,4 +1,5 @@
 export const theme = {
+  maxWidth: "375px",
   color: {
     primary: "#1EB17B",
     sub1: "#B6E4CB",

--- a/gamgyul-front/src/utils/fontStyles.jsx
+++ b/gamgyul-front/src/utils/fontStyles.jsx
@@ -3,6 +3,6 @@ export function applyFontStyles(font) {
   return `
         font-size: ${font.fontSize};
         font-weight: ${font.fontWeight};
-        line-heigth: ${font.lineHeight};
+        line-height: ${font.lineHeight};
     `;
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->
## #️⃣ 연관된 이슈

<!-- ex) close #이슈번호 -->
> - close #24 

## 📝 작업 내용
- [x] 5.1.1. 저장한 관광지 목록 페이지 마크업 + 퍼블리싱
- [x] 5.1.2. 저장한 경로 목록 페이지 마크업 + 퍼블리싱
- [x] TabButton Style 분리 및 퍼블리싱

## 📸 스크린샷
> <!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
![image](https://github.com/user-attachments/assets/e7ac63da-406c-4aa3-a70e-e69429a36fd6) | ![image](https://github.com/user-attachments/assets/244f805c-bfe4-4a8f-bdaa-f852fc6fecc7)
---|---|

- 내 여행 페이지의 마크업 & 퍼블리싱을 진행했습니다.
- 상단의 탭바 (장소 / 경로) 는 디테일페이지에 재사용될 것이라고 생각해 스타일을 따로 분리해뒀습니다.

## 📌 이슈 사항
><!-- 코드 내용 자유롭게 작성해주세요 -->
- 상단 탭바는 공통 컴포넌트의 버튼 폴더에, `TabButton.style.jsx`로 분리해뒀습니다. 코드 내용은 다음과 같습니다.
```jsx
import styled from "styled-components";
import { theme } from "../../../style/theme";
import { applyFontStyles } from "../../../utils/fontStyles";

export const TabButton = styled.button`
  ${({ fontSize }) => applyFontStyles(fontSize)}
  background-color: inherit;
  width: ${({ btnCnt }) => (btnCnt ? `${100 / btnCnt}%` : "auto")};
  height: 48px;
  border: none;
  border-bottom: 3px solid ${({ isActive }) => (isActive ? theme.color.primary : theme.color.gray3)};
  color: ${({ isActive }) => !isActive && theme.color.gray2};
`;
```
- 이렇게 분리된 버튼을 사용하는 방법은, 아래 코드와 같습니다.
```jsx
<nav aria-label="내 여행 (장소 / 경로)">
  <TabButton
    onClick={() => setActiveTab("places")}
    isActive={activeTab === "places"}
    fontSize={theme.font.body1}
    btnCnt={2}
  >
    장소
  </TabButton>
  <TabButton
    onClick={() => setActiveTab("routes")}
    isActive={activeTab === "routes"}
    fontSize={theme.font.body1}
    btnCnt={2}
  >
    경로
  </TabButton>
</nav>
```
- **`isActive={activeTab === "places"}`** : 활성화된 탭버튼 표시
- **`fontSize={theme.font.body1}`** : 폰트 사이즈 prop
- **`btnCnt={2}`** : 한 줄에 들어갈 탭버튼 개수 -> 개수에 따라 width가 변경됩니다.

## 💬리뷰 요구사항(선택)

><!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
